### PR TITLE
Add lookup conf & go.mod support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You can also run `gomove --help` for help.
 	   
 	GLOBAL OPTIONS:
 	   --dir, -d "./"		directory to scan
+	   --conf, c			lookup config for multiple dependency changes
 	   --file, -f 			only move imports in a file
 	   --safe-mode, -s "false"	run program in safe mode (comments will be wiped)
 	   --help, -h			show help

--- a/main.go
+++ b/main.go
@@ -1,6 +1,11 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -24,6 +29,11 @@ func main() {
 			Usage: "directory to scan. files under vendor/ are ignored",
 		},
 		cli.StringFlag{
+			Name:  "conf, c",
+			Value: "",
+			Usage: "json lookup config for updating multiple paths at the same time",
+		},
+		cli.StringFlag{
 			Name:  "file, f",
 			Usage: "only move imports in a file",
 		},
@@ -35,15 +45,37 @@ func main() {
 	}
 
 	app.Action = func(c *cli.Context) {
+		lookup := make(map[string]string)
 		file := c.String("file")
 		dir := c.String("dir")
+		conf := c.String("conf")
+
 		from := c.Args().Get(0)
 		to := c.Args().Get(1)
+
+		if conf != "" {
+			b, err := os.ReadFile(conf)
+			if err != nil {
+				log.Fatalf("error reading file %v: %v", conf, err)
+			}
+			if err := json.Unmarshal(b, &lookup); err != nil {
+				log.Fatalf("error parsing file %v: %v", conf, err)
+			}
+
+		} else if from == "" || to == "" {
+			cli.ShowAppHelp(c)
+			log.Println("is this needed?")
+			return
+
+		} else {
+			lookup = map[string]string{from: to}
+		}
 
 		if file != "" {
 			ProcessFile(file, from, to, c)
 		} else {
-			ScanDir(dir, from, to, c)
+			ParseMod(dir, lookup)
+			ScanDir(dir, lookup, c)
 		}
 
 	}
@@ -52,29 +84,94 @@ func main() {
 }
 
 // ScanDir scans a directory for go files and
-func ScanDir(dir string, from string, to string, c *cli.Context) {
-	// If from and to are not empty scan all files
-	if from != "" && to != "" {
-		// construct the path of the vendor dir of the project for prefix matching
-		vendorDir := path.Join(dir, "vendor")
-		// Scan directory for files
-		filepath.Walk(dir, func(filePath string, info os.FileInfo, err error) error {
-			// ignore vendor path
-			if matched := strings.HasPrefix(filePath, vendorDir); matched {
-				return nil
-			}
-			// Only process go files
-			if path.Ext(filePath) == ".go" {
+func ScanDir(dir string, lookup map[string]string, c *cli.Context) {
+	// construct the path of the vendor dir of the project for prefix matching
+	vendorDir := path.Join(dir, "vendor")
+	// Scan directory for files
+	filepath.Walk(dir, func(filePath string, info os.FileInfo, err error) error {
+		// ignore vendor path
+		if matched := strings.HasPrefix(filePath, vendorDir); matched {
+			return nil
+		}
+		// Only process go files
+		if path.Ext(filePath) == ".go" {
+			fmt.Println(blackOnWhite+"Processing file", filePath, reset)
+			for from, to := range lookup {
 				ProcessFile(filePath, from, to, c)
 			}
+		}
 
-			return nil
-		})
+		return nil
+	})
+}
 
-	} else {
-		cli.ShowAppHelp(c)
+// ParseMod goes through the go.mod and go.sum file
+// it will optimize the lookup map by removing values not found in the
+// go.mod file.
+func ParseMod(dir string, lookup map[string]string) {
+	foundKeys := make(map[string]string)
+	modPath := strings.TrimRight(dir, "/") + "/go.mod"
+	modFile, err := os.ReadFile(modPath)
+	if err != nil {
+		fmt.Println(err)
+		return
 	}
 
+	sumPath := strings.TrimRight(dir, "/") + "/go.sum"
+	sumFile, err := os.ReadFile(sumPath)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	numChanges := 0
+	output := ""
+	scanner := bufio.NewScanner(bytes.NewReader(modFile))
+modScan:
+	for scanLine := 0; scanner.Scan(); scanLine++ {
+		line := scanner.Text()
+
+		for key, value := range lookup {
+			if strings.Contains(line, key) {
+				numChanges++
+				foundKeys[key] = value
+				output += strings.Replace(line, key, value, 1) + "\n"
+				continue modScan
+			}
+		}
+		output += line + "\n"
+	}
+	// remove unneeded keys
+	for k := range lookup {
+		if _, found := foundKeys[k]; !found {
+			fmt.Printf("Remove unused key: %v\n", k)
+			delete(lookup, k)
+		}
+	}
+
+	if numChanges > 0 {
+		os.WriteFile(modPath, []byte(output), os.ModePerm)
+	}
+
+	// update go.sum file
+	numChanges = 0
+	output = ""
+	scanner = bufio.NewScanner(bytes.NewReader(sumFile))
+sumScan:
+	for scanLine := 0; scanner.Scan(); scanLine++ {
+		line := scanner.Text()
+
+		for key, _ := range lookup {
+			if strings.Contains(line, key) {
+				numChanges++
+				continue sumScan
+			}
+		}
+		output += line + "\n"
+	}
+	if numChanges > 0 {
+		os.WriteFile(sumPath, []byte(output), os.ModePerm)
+	}
 }
 
 // ProcessFile processes file according to what mode is chosen

--- a/native.go
+++ b/native.go
@@ -11,18 +11,19 @@ import (
 	"github.com/mgutz/ansi"
 )
 
-// ProcessFileNative processes files uing native string search instead of ast parsing
+var (
+	red          = ansi.ColorCode("red+bh")
+	white        = ansi.ColorCode("white+bh")
+	green        = ansi.ColorCode("green+bh")
+	yellow       = ansi.ColorCode("yellow+bh")
+	blackOnWhite = ansi.ColorCode("black+b:white+h")
+	//Reset the color
+	reset = ansi.ColorCode("reset")
+)
+
+// ProcessFileNative processes files using native string search instead of ast parsing
 func ProcessFileNative(filePath string, from string, to string) {
 	//Colors to be used on the console
-	red := ansi.ColorCode("red+bh")
-	white := ansi.ColorCode("white+bh")
-	green := ansi.ColorCode("green+bh")
-	yellow := ansi.ColorCode("yellow+bh")
-	blackOnWhite := ansi.ColorCode("black+b:white+h")
-	//Reset the color
-	reset := ansi.ColorCode("reset")
-
-	fmt.Println(blackOnWhite+"Processing file", filePath, reset)
 
 	// Open file to read
 	fileContent, err := ioutil.ReadFile(filePath)
@@ -75,10 +76,10 @@ func ProcessFileNative(filePath string, from string, to string) {
 
 		// Change isImportLine accordingly if import statements are detected
 		if strings.Contains(bareLine, "import(") {
-			fmt.Println(green+"Found Multiple Imports Starting On Line", scanLine, reset)
+			//	fmt.Println(green+"Found Multiple Imports Starting On Line", scanLine, reset)
 			isImportLine = true
 		} else if isImportLine && strings.Contains(bareLine, ")") {
-			fmt.Println(green+"Imports Finish On Line", scanLine, reset)
+			//	fmt.Println(green+"Imports Finish On Line", scanLine, reset)
 			isImportLine = false
 		}
 
@@ -112,14 +113,14 @@ func ProcessFileNative(filePath string, from string, to string) {
 		fmt.Print(yellow+
 			"File",
 			filePath,
-			"saved after",
+			"saved after ",
 			numChanges,
-			"changes",
-			reset, "\n\n\n")
+			" changes",
+			reset, "\n")
 		ioutil.WriteFile(filePath, []byte(output), os.ModePerm)
-	} else {
+	} /* else {
 		fmt.Print(yellow+
 			"No changes to write on this file.",
-			reset, "\n\n\n")
-	}
+			reset, "\n\n\")
+	} */
 }

--- a/repos.json
+++ b/repos.json
@@ -1,0 +1,5 @@
+{
+    "github.rakops.com/SD": "github.com/rakuten-rad-SD",
+    "github.rakops.com/rm": "github.com/rakuten-rad-rm",
+    "github.rakops.com/rmp": "github.com/rakuten-rad-rmp"
+}


### PR DESCRIPTION
- lookup config allows multiple dependencies at the same time. This is useful when moving a whole org. 
- #8 updating the go.mod file and deleting associated checksums in the go.sum file. You should run go mod tidy afterwards. 
- Removed some noisy logs when replacing multiple dependencies at the same time. 